### PR TITLE
build: no need to specify assertj-core version

### DIFF
--- a/buildSrc/src/main/kotlin/org.projectcheckins.micronaut-modules-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.projectcheckins.micronaut-modules-conventions.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
     // AssertJ
-    testImplementation("org.assertj:assertj-core:3.25.1")
+    testImplementation("org.assertj:assertj-core")
 
     // Logging
     testRuntimeOnly("ch.qos.logback:logback-classic")

--- a/netty/build.gradle.kts
+++ b/netty/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     testImplementation("io.micronaut:micronaut-http-client-jdk")
 
     // AssertJ
-    testImplementation("org.assertj:assertj-core:3.25.1")
+    testImplementation("org.assertj:assertj-core")
 
     // Persistence
     implementation(project(":repository-eclipsestore"))

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -14,5 +14,5 @@ dependencies {
     testRuntimeOnly("ch.qos.logback:logback-classic")
 
     // AssertJ
-    testImplementation("org.assertj:assertj-core:3.25.1")
+    testImplementation("org.assertj:assertj-core")
 }


### PR DESCRIPTION
assertj version is defined in Micronaut Platform BOM.