### PR TITLE
build: java warnings as errors

### DIFF
--- a/buildSrc/src/main/kotlin/org.projectcheckins.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.projectcheckins.java-common-conventions.gradle.kts
@@ -37,8 +37,3 @@ java {
     targetCompatibility = JavaVersion.toVersion("21")
 }
 
-tasks.withType<JavaCompile> {
-	val compilerArgs = options.compilerArgs
-	compilerArgs.add("-Werror")
-	compilerArgs.add("-Xlint:all,-serial,-processing")
-}

--- a/buildSrc/src/main/kotlin/org.projectcheckins.java-warning-errors.gradle.kts
+++ b/buildSrc/src/main/kotlin/org.projectcheckins.java-warning-errors.gradle.kts
@@ -1,0 +1,5 @@
+tasks.withType<JavaCompile> {
+    val compilerArgs = options.compilerArgs
+    compilerArgs.add("-Werror")
+    compilerArgs.add("-Xlint:all,-serial,-processing")
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.projectcheckins.micronaut-modules-conventions")
+    id("org.projectcheckins.java-warning-errors")
 }
 dependencies {
     api("io.micronaut.security:micronaut-security")

--- a/http/build.gradle.kts
+++ b/http/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.projectcheckins.micronaut-http-modules-conventions")
+    id("org.projectcheckins.java-warning-errors")
 }
 dependencies {
     api(project(":core"))

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.projectcheckins.micronaut-boms")
+    id("org.projectcheckins.java-warning-errors")
 }
 dependencies {
     implementation("io.micronaut:micronaut-aop")

--- a/repository-eclipsestore/build.gradle.kts
+++ b/repository-eclipsestore/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.projectcheckins.micronaut-modules-conventions")
+    id("org.projectcheckins.java-warning-errors")
 }
 dependencies {
     implementation(project(":core"))

--- a/security-http/build.gradle.kts
+++ b/security-http/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.projectcheckins.micronaut-http-modules-conventions")
+    id("org.projectcheckins.java-warning-errors")
 }
 dependencies {
     api(project(":security"))

--- a/security/build.gradle.kts
+++ b/security/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.projectcheckins.micronaut-modules-conventions")
+    id("org.projectcheckins.java-warning-errors")
 }
 
 dependencies {


### PR DESCRIPTION
Make java warnings as errors as opt-in for new modules

see: https://github.com/UnityFoundation-io/projectcheckins.org/pull/8