### PR TITLE
fix: TimeOfDay persistence

### DIFF
--- a/core/src/main/java/org/projectcheckins/core/forms/TimeOfDay.java
+++ b/core/src/main/java/org/projectcheckins/core/forms/TimeOfDay.java
@@ -10,7 +10,7 @@ public enum TimeOfDay {
     END((t, p) -> p.endOfDay()),
     FIXED((t, p) -> t);
 
-    private final BiFunction<LocalTime, Profile, LocalTime> function;
+    private transient final BiFunction<LocalTime, Profile, LocalTime> function;
 
     TimeOfDay(BiFunction<LocalTime, Profile, LocalTime> function) {
         this.function = function;


### PR DESCRIPTION
Eclipse persistence layer can't deserialize `TimeOfDay` properly:

```
Caused by: org.eclipse.serializer.persistence.exceptions.PersistenceException: Missing runtime type for required type handler for type: org.projectcheckins.core.forms.TimeOfDay$$Lambda/0x0000027f2bbe7940
	at org.eclipse.serializer.persistence.types.PersistenceTypeHandlerManager$Default.validateExistingType(PersistenceTypeHandlerManager.java:390)
	at org.eclipse.serializer.persistence.types.PersistenceTypeHandlerManager$Default.ensureTypeHandler(PersistenceTypeHandlerManager.java:439)
	at org.eclipse.serializer.persistence.types.PersistenceTypeHandlerManager$Default.lambda$ensureTypeHandlers$2(PersistenceTypeHandlerManager.java:486)
	at org.eclipse.serializer.collections.ChainStorageStrong.iterate(ChainStorageStrong.java:1316)
	at org.eclipse.serializer.collections.HashEnum.iterate(HashEnum.java:693)
	at org.eclipse.serializer.persistence.types.PersistenceTypeHandlerManager$Default.ensureTypeHandlers(PersistenceTypeHandlerManager.java:485)
	at org.eclipse.serializer.persistence.types.PersistenceTypeHandlerManager$Default.ensureTypeHandlersByTypeIds(PersistenceTypeHandlerManager.java:477)
	at org.eclipse.store.storage.embedded.types.EmbeddedStorageManager$Default.ensureRequiredTypeHandlers(EmbeddedStorageManager.java:332)
	at org.eclipse.store.storage.embedded.types.EmbeddedStorageManager$Default.start(EmbeddedStorageManager.java:242)
	at org.eclipse.store.storage.embedded.types.EmbeddedStorageManager$Default.start(EmbeddedStorageManager.java:90)
	at io.micronaut.eclipsestore.conf.StorageManagerFactory.createStorageManager(StorageManagerFactory.java:68)
	at io.micronaut.eclipsestore.conf.$StorageManagerFactory$CreateStorageManager0$Definition.doInstantiate(Unknown Source)
	at io.micronaut.context.AbstractInitializableBeanDefinition.instantiate(AbstractInitializableBeanDefinition.java:774)
	at io.micronaut.context.BeanDefinitionDelegate.instantiate(BeanDefinitionDelegate.java:156)
	at io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2332)
	... 61 common frames omitted
```