### PR TITLE
test: refactor assertions

### DIFF
--- a/http/src/test/java/org/projectcheckins/http/controllers/AnswerControllerTest.java
+++ b/http/src/test/java/org/projectcheckins/http/controllers/AnswerControllerTest.java
@@ -101,20 +101,20 @@ class AnswerControllerTest {
 
         final String anyAnswerId = answerRepositoryMock.getAnswers().stream().filter(a -> a.answerDate().equals(expectedMarkdownAnswerDate)).map(Answer::id).findAny().orElse(null);
         Assertions.assertThat(client.exchange(BrowserRequest.GET(UriBuilder.of("/question").path(questionId).path("answer").path(anyAnswerId).path("show").build()), String.class))
-                .matches(htmlPage())
-                .matches(htmlBody("""
+                .satisfies(htmlPage())
+                .satisfies(htmlBody("""
                         <div class="date">"""))
-                .matches(htmlBody("Monday, March 11"))
-                .matches(htmlBody("""
+                .satisfies(htmlBody("Monday, March 11"))
+                .satisfies(htmlBody("""
                         <div class="respondent">"""))
-                .matches(htmlBody("<b>Code Monkey</b>"))
-                .matches(htmlBody("""
+                .satisfies(htmlBody("<b>Code Monkey</b>"))
+                .satisfies(htmlBody("""
                         <a href="/question/list">"""))
-                .matches(htmlBody("""
+                .satisfies(htmlBody("""
                         <a href="/question/123/show">"""))
-                .matches(htmlBody(Pattern.compile("""
+                .satisfies(htmlBody(Pattern.compile("""
                         <a href="/question/123/answer/.*/show">""")))
-                .matches(htmlBody(Pattern.compile("""
+                .satisfies(htmlBody(Pattern.compile("""
                         <a href="/question/123/answer/.*/edit">""")));
     }
 
@@ -156,11 +156,11 @@ class AnswerControllerTest {
         answerRepository.update(new AnswerRecord(id, questionId, SDELAMO.getName(), LocalDate.now(), Format.MARKDOWN, "Markdown answer"), null);
         authenticationFetcher.setAuthentication(SDELAMO);
         Assertions.assertThat(client.exchange(request, String.class))
-                .matches(htmlPage())
-                .matches(htmlBody("/question/123/answer/" + id + "/update"))
-                .matches(htmlBody("""
+                .satisfies(htmlPage())
+                .satisfies(htmlBody("/question/123/answer/" + id + "/update"))
+                .satisfies(htmlBody("""
                         <input type="hidden" name="format" value="MARKDOWN"/>"""))
-                .matches(htmlBody("""
+                .satisfies(htmlBody("""
                         <textarea name="content" id="content" class="form-control" required="required">Markdown answer</textarea>"""));
     }
 
@@ -174,11 +174,11 @@ class AnswerControllerTest {
         answerRepository.update(new AnswerRecord(id, questionId, SDELAMO.getName(), LocalDate.now(), Format.WYSIWYG, "Rich text answer"), null);
         authenticationFetcher.setAuthentication(SDELAMO);
         Assertions.assertThat(client.exchange(request, String.class))
-                .matches(htmlPage())
-                .matches(htmlBody("/question/123/answer/" + id + "/update"))
-                .matches(htmlBody("""
+                .satisfies(htmlPage())
+                .satisfies(htmlBody("/question/123/answer/" + id + "/update"))
+                .satisfies(htmlBody("""
                         <input type="hidden" name="format" value="WYSIWYG"/>"""))
-                .matches(htmlBody("""
+                .satisfies(htmlBody("""
                         <input type="hidden" name="content" value="Rich text answer" id="content"/><trix-editor class="form-control" input="content"></trix-editor>"""));
     }
 
@@ -209,8 +209,8 @@ class AnswerControllerTest {
         answerRepository.update(new AnswerRecord(id, questionId, SDELAMO.getName(), LocalDate.now(), Format.MARKDOWN, "Lorem ipsum"), null);
         authenticationFetcher.setAuthentication(SDELAMO);
         Assertions.assertThat(client.exchange(request, String.class))
-                .matches(htmlPage())
-                .matches(htmlBody("""
+                .satisfies(htmlPage())
+                .satisfies(htmlBody("""
                         <div id="contentValidationServerFeedback" class="invalid-feedback">must not be blank</div>"""));
     }
 

--- a/http/src/test/java/org/projectcheckins/http/controllers/HomeControllerTest.java
+++ b/http/src/test/java/org/projectcheckins/http/controllers/HomeControllerTest.java
@@ -20,6 +20,6 @@ class HomeControllerTest {
     void crud(@Client("/") HttpClient httpClient) {
         BlockingHttpClient client = httpClient.toBlocking();
         assertThat(client.exchange("/"))
-            .matches(redirection("/question/list"));
+            .satisfies(redirection("/question/list"));
     }
 }

--- a/http/src/test/java/org/projectcheckins/http/controllers/NotFoundControllerTest.java
+++ b/http/src/test/java/org/projectcheckins/http/controllers/NotFoundControllerTest.java
@@ -20,7 +20,7 @@ class NotFoundControllerTest {
     void crud(@Client("/") HttpClient httpClient) {
         BlockingHttpClient client = httpClient.toBlocking();
         assertThat(client.exchange(BrowserRequest.GET("/notFound"), String.class))
-            .matches(htmlPage())
-            .matches(htmlBody("Not Found"));
+            .satisfies(htmlPage())
+            .satisfies(htmlBody("Not Found"));
     }
 }

--- a/http/src/test/java/org/projectcheckins/http/controllers/ProfileControllerSecurityTest.java
+++ b/http/src/test/java/org/projectcheckins/http/controllers/ProfileControllerSecurityTest.java
@@ -24,16 +24,16 @@ class ProfileControllerSecurityTest {
     void crud(@Client("/") HttpClient httpClient) {
         BlockingHttpClient client = httpClient.toBlocking();
         assertThat(client.exchange(BrowserRequest.GET("/profile/show")))
-            .matches(unauthorized());
+            .satisfies(unauthorized());
 
         assertThat(client.exchange(BrowserRequest.GET("/profile/edit")))
-            .matches(unauthorized());
+            .satisfies(unauthorized());
 
         assertThat(client.exchange(BrowserRequest.POST("/profile/update", Map.of(
             "timeZone", TimeZone.getDefault().getID(),
             "firstDayOfWeek", DayOfWeek.MONDAY.name(),
             "using24HourClock", true))))
-            .matches(unauthorized());
+            .satisfies(unauthorized());
     }
 
 }

--- a/http/src/test/java/org/projectcheckins/http/controllers/ProfileControllerTest.java
+++ b/http/src/test/java/org/projectcheckins/http/controllers/ProfileControllerTest.java
@@ -49,13 +49,13 @@ class ProfileControllerTest {
     Map<CharSequence, CharSequence> auth = Map.of(AUTHORIZATION, "Basic YWRtaW46YWRtaW4=");
 
     assertThat(client.exchange(BrowserRequest.GET("/profile/show", auth), String.class))
-        .matches(htmlPage())
-        .matches(htmlBody("/security/changePassword"))
-        .matches(htmlBody("/profile/edit"));
+        .satisfies(htmlPage())
+        .satisfies(htmlBody("/security/changePassword"))
+        .satisfies(htmlBody("/profile/edit"));
 
     assertThat(client.exchange(BrowserRequest.GET("/profile/edit", auth), String.class))
-        .matches(htmlPage())
-        .matches(htmlBody("/profile/update"));
+        .satisfies(htmlPage())
+        .satisfies(htmlBody("/profile/update"));
 
     assertThat(client.exchange(BrowserRequest.POST("/profile/update", auth, Map.of(
         "timeZone", TimeZone.getDefault().getID(),
@@ -66,12 +66,12 @@ class ProfileControllerTest {
             "format", Format.WYSIWYG,
         "firstName", "Guillermo",
         "lastName", "Calvo"))))
-        .matches(redirection("/profile/show"));
+        .satisfies(redirection("/profile/show"));
 
       assertThat(client.exchange(BrowserRequest.GET("/profile/show", auth), String.class))
-              .matches(htmlPage())
-              .matches(htmlBody("Guillermo Calvo"))
-              .matches(htmlBody("Rich Text"));
+              .satisfies(htmlPage())
+              .satisfies(htmlBody("Guillermo Calvo"))
+              .satisfies(htmlBody("Rich Text"));
   }
 
   @Requires(property = "spec.name", value = "ProfileControllerTest")

--- a/http/src/test/java/org/projectcheckins/http/controllers/QuestionControllerFormTest.java
+++ b/http/src/test/java/org/projectcheckins/http/controllers/QuestionControllerFormTest.java
@@ -87,7 +87,7 @@ class QuestionControllerFormTest {
         String title = "What are you working on?";
         HttpResponse<?> saveResponse = client.exchange(BrowserRequest.POST("/question/save", "title="+title+"&howOften=DAILY_ON&dailyOnDay=MONDAY&dailyOnDay=TUESDAY&dailyOnDay=WEDNESDAY&dailyOnDay=THURSDAY&dailyOnDay=FRIDAY&timeOfDay=END&fixedTime=16:30&respondentIds=user1"));
         assertThat(saveResponse)
-            .matches(redirection(s -> s.startsWith("/question") && s.endsWith("/show")));
+            .satisfies(redirection(s -> assertThat(s).startsWith("/question").endsWith("/show")));
 
         String location = saveResponse.getHeaders().get(HttpHeaders.LOCATION);
         String id = location.substring(location.indexOf("/question/") + "/question/".length(), location.lastIndexOf("/show"));
@@ -109,7 +109,7 @@ class QuestionControllerFormTest {
         String updateBody = "title="+updatedTitle+"&howOften=DAILY_ON&dailyOnDay=MONDAY&dailyOnDay=TUESDAY&dailyOnDay=WEDNESDAY&dailyOnDay=THURSDAY&dailyOnDay=FRIDAY&timeOfDay=END&fixedTime=16:30&respondentIds=user1";
 
         assertThat(client.exchange(BrowserRequest.POST(updateUri.toString(), updateBody)))
-            .matches(redirection(s -> s.equals("/question/" + id + "/show")));
+            .satisfies(redirection(s -> s.equals("/question/" + id + "/show")));
 
         assertThat(client.retrieve(BrowserRequest.GET(UriBuilder.of("/question").path(id).path("edit").build()), String.class))
             .doesNotContain(title)
@@ -117,7 +117,7 @@ class QuestionControllerFormTest {
 
         URI deleteUri = UriBuilder.of("/question").path(id).path("delete").build();
         assertThat(client.exchange(BrowserRequest.POST(deleteUri.toString(), Collections.emptyMap())))
-            .matches(redirection("/question/list"));
+            .satisfies(redirection("/question/list"));
 
         assertThat(questionRepository.findAll()).isEmpty();
     }

--- a/http/src/test/java/org/projectcheckins/http/controllers/QuestionControllerSecurityTest.java
+++ b/http/src/test/java/org/projectcheckins/http/controllers/QuestionControllerSecurityTest.java
@@ -22,13 +22,13 @@ class QuestionControllerSecurityTest {
     void crud(@Client("/") HttpClient httpClient) {
         BlockingHttpClient client = httpClient.toBlocking();
         assertThat(client.exchange(BrowserRequest.GET("/question/list")))
-            .matches(unauthorized());
+            .satisfies(unauthorized());
 
         assertThat(client.exchange(BrowserRequest.GET(UriBuilder.of("/question").path("xx").path("edit").build())))
-            .matches(unauthorized());
+            .satisfies(unauthorized());
 
         assertThat(client.exchange(BrowserRequest.GET(UriBuilder.of("/question").path("create").build())))
-            .matches(unauthorized());
+            .satisfies(unauthorized());
     }
 
 }

--- a/http/src/test/java/org/projectcheckins/http/controllers/QuestionControllerTest.java
+++ b/http/src/test/java/org/projectcheckins/http/controllers/QuestionControllerTest.java
@@ -114,35 +114,35 @@ class QuestionControllerTest {
                 .bodyHtmlTest(html -> html.contains("You must select at least one day")); // days missing when selecting DAILY_ON
 
         assertThat(client.exchange(BrowserRequest.GET("/question/list"), String.class))
-            .matches(htmlPage())
-                .matches(htmlBody(Pattern.compile("""
+            .satisfies(htmlPage())
+                .satisfies(htmlBody(Pattern.compile("""
                 Asking 1 person\\s*every weekday\\s*at the end of the day.""")));
 
         assertThat(client.exchange(BrowserRequest.GET(UriBuilder.of("/question").path(questionId).path("edit").build()), String.class))
-            .matches(htmlPage())
-            .matches(htmlBody("""
+            .satisfies(htmlPage())
+            .satisfies(htmlBody("""
                 <li class="breadcrumb-item"><a href="/question/list">"""));
 
         assertThat(client.exchange(BrowserRequest.GET(UriBuilder.of("/question").path("yyy").path("edit").build()), String.class))
-            .matches(redirection("/notFound"));
+            .satisfies(redirection("/notFound"));
 
         answerRepository.save(new AnswerRecord("zzz", "yyy", SDELAMO.getName(), LocalDate.now(), Format.MARKDOWN, "This is *my* answer."), null);
 
         assertThat(client.exchange(BrowserRequest.GET(UriBuilder.of("/question").path("xxx").path("show").build()), String.class))
-            .matches(htmlPage())
-            .matches(htmlBody(Pattern.compile("""
+            .satisfies(htmlPage())
+            .satisfies(htmlBody(Pattern.compile("""
                 Asking 1 person\\s*every weekday\\s*at the end of the day.""")))
-                .matches(htmlBody("Today"))
-                .matches(htmlBody("This is <em>my</em> answer."))
-            .matches(htmlBody("/question/yyy/answer/zzz/edit"))
-            .matches(htmlBody("""
+                .satisfies(htmlBody("Today"))
+                .satisfies(htmlBody("This is <em>my</em> answer."))
+            .satisfies(htmlBody("/question/yyy/answer/zzz/edit"))
+            .satisfies(htmlBody("""
                 <li class="breadcrumb-item"><a href="/question/list">"""));
 
         assertThat(client.exchange(BrowserRequest.GET(UriBuilder.of("/question").path("create").build()), String.class))
-            .matches(htmlPage())
-            .matches(htmlBody("""
+            .satisfies(htmlPage())
+            .satisfies(htmlBody("""
                 <li class="breadcrumb-item"><a href="/question/list">"""))
-            .matches(htmlBody(Pattern.compile("""
+            .satisfies(htmlBody(Pattern.compile("""
                 <input type="text" class="form-control"\\s*id="title""")));
     }
 

--- a/http/src/test/java/org/projectcheckins/http/controllers/UnauthorizedControllerTest.java
+++ b/http/src/test/java/org/projectcheckins/http/controllers/UnauthorizedControllerTest.java
@@ -20,7 +20,7 @@ class UnauthorizedControllerTest {
     void crud(@Client("/") HttpClient httpClient) {
         BlockingHttpClient client = httpClient.toBlocking();
         assertThat(client.exchange(BrowserRequest.GET("/unauthorized"), String.class))
-            .matches(htmlPage())
-            .matches(htmlBody("Unauthorized"));
+            .satisfies(htmlPage())
+            .satisfies(htmlBody("Unauthorized"));
     }
 }

--- a/security-http/src/test/java/org/projectcheckins/security/http/controllers/TeamControllerTest.java
+++ b/security-http/src/test/java/org/projectcheckins/security/http/controllers/TeamControllerTest.java
@@ -110,14 +110,14 @@ class TeamControllerTest {
     void testListTeamMembers(@Client("/") HttpClient httpClient, AuthenticationFetcherMock authenticationFetcher) {
         final BlockingHttpClient client = httpClient.toBlocking();
         Assertions.assertThat(client.exchange(BrowserRequest.GET(URI_LIST), String.class))
-                .matches(htmlPage())
-                .matches(htmlBody("""
+                .satisfies(htmlPage())
+                .satisfies(htmlBody("""
                         <span>User One</span>"""))
-                .matches(htmlBody("""
+                .satisfies(htmlBody("""
                         <code>user2@email.com</code>"""))
-                .matches(htmlBody("""
+                .satisfies(htmlBody("""
                         <code>pending@email.com</code>"""))
-                .matches(htmlBody(Pattern.compile("""
+                .satisfies(htmlBody(Pattern.compile("""
                         <a href="/team/create">""")));
     }
 
@@ -125,14 +125,14 @@ class TeamControllerTest {
     void testCreateTeamMember(@Client("/") HttpClient httpClient, AuthenticationFetcherMock authenticationFetcher) {
         final BlockingHttpClient client = httpClient.toBlocking();
         Assertions.assertThat(client.exchange(BrowserRequest.GET(URI_CREATE), String.class))
-                .matches(htmlPage())
-                .matches(htmlBody("""
+                .satisfies(htmlPage())
+                .satisfies(htmlBody("""
                         <a href="/">"""))
-                .matches(htmlBody("""
+                .satisfies(htmlBody("""
                         <a href="/team/list">"""))
-                .matches(htmlBody("""
+                .satisfies(htmlBody("""
                         <form action="/team/save" method="post">"""))
-                .matches(htmlBody("""
+                .satisfies(htmlBody("""
                         <input type="email" name="email" value="" id="email" class="form-control" required="required"/>"""));
     }
 
@@ -142,8 +142,8 @@ class TeamControllerTest {
         final Map<String, Object> body = Map.of("email", "user3@email.com");
         final HttpRequest<?> request = BrowserRequest.POST(URI_SAVE, body);
         Assertions.assertThat(client.exchange(request))
-                .matches(status(HttpStatus.SEE_OTHER))
-                .matches(location("/team/list"));
+                .satisfies(status(HttpStatus.SEE_OTHER))
+                .satisfies(location("/team/list"));
     }
 
     @Test

--- a/test-utils/src/main/java/org/projectcheckins/test/HttpClientResponseExceptionAssert.java
+++ b/test-utils/src/main/java/org/projectcheckins/test/HttpClientResponseExceptionAssert.java
@@ -6,7 +6,8 @@ import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.ThrowableAssert;
-import java.util.function.Predicate;
+import java.util.function.Consumer;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class HttpClientResponseExceptionAssert extends AbstractAssert<HttpClientResponseExceptionAssert, AbstractObjectAssert<?, HttpClientResponseException>> {
@@ -27,12 +28,12 @@ public class HttpClientResponseExceptionAssert extends AbstractAssert<HttpClient
     }
 
     public HttpClientResponseExceptionAssert bodyHtmlContains(String expected) {
-        return bodyHtmlTest(html -> html.contains(expected));
+        return bodyHtmlTest(html -> assertThat(html).contains(expected));
     }
 
-    public HttpClientResponseExceptionAssert bodyHtmlTest(Predicate<String> expected) {
+    public HttpClientResponseExceptionAssert bodyHtmlTest(Consumer<String> expected) {
                     actual.extracting(HttpClientResponseException::getResponse)
-                                    .matches(htmlBody(expected));
+                                    .satisfies(htmlBody(expected));
         return this;
     }
 
@@ -42,9 +43,8 @@ public class HttpClientResponseExceptionAssert extends AbstractAssert<HttpClient
         return this;
     }
 
-    private static Predicate<HttpResponse<?>> htmlBody(Predicate<String> expected) {
-        return response -> response.getBody(String.class)
-                .filter(expected)
-                .isPresent();
+    private static Consumer<HttpResponse<?>> htmlBody(Consumer<String> expected) {
+        return response -> assertThat(response.getBody(String.class))
+                              .hasValueSatisfying(expected);
     }
 }


### PR DESCRIPTION
We've been using `assertThat(x).matches(predicate)` to validate HTTP responses, but `assertThat(x).satisfies(consumer)` yields much better error messages when tests fail.