### PR TITLE
add user as view model processor

### DIFF
--- a/core/src/main/java/org/projectcheckins/core/viewmodelprocessors/TimeZoneFormatterViewModelProcessor.java
+++ b/core/src/main/java/org/projectcheckins/core/viewmodelprocessors/TimeZoneFormatterViewModelProcessor.java
@@ -3,6 +3,8 @@ package org.projectcheckins.core.viewmodelprocessors;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.HttpRequest;
 import jakarta.inject.Singleton;
+import org.projectcheckins.security.MapViewModelProcessor;
+
 import java.util.Map;
 
 @Singleton

--- a/http/src/main/java/org/projectcheckins/http/viewmodelprocessors/LocalDateFormatterViewModelProcessor.java
+++ b/http/src/main/java/org/projectcheckins/http/viewmodelprocessors/LocalDateFormatterViewModelProcessor.java
@@ -4,9 +4,8 @@ import io.micronaut.context.MessageSource;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.server.util.locale.HttpLocaleResolver;
-import io.micronaut.views.ModelAndView;
 import jakarta.inject.Singleton;
-import org.projectcheckins.core.viewmodelprocessors.MapViewModelProcessor;
+import org.projectcheckins.security.MapViewModelProcessor;
 
 import java.util.Locale;
 import java.util.Map;

--- a/netty/src/main/resources/application.properties
+++ b/netty/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+micronaut.security.views-model-decorator.enabled=false
 micronaut.security.authentication=session
 micronaut.security.redirect.forbidden.url=/unauthorized
 micronaut.security.redirect.unauthorized.url=/security/login

--- a/security-http/src/main/java/org/projectcheckins/security/http/TeamController.java
+++ b/security-http/src/main/java/org/projectcheckins/security/http/TeamController.java
@@ -58,7 +58,6 @@ class TeamController {
     private static final String MODEL_INVITATIONS = "invitations";
     private static final String MEMBER_FORM = "memberForm";
     private static final String MODEL_BREADCRUMBS = "breadcrumbs";
-    private static final String MODEL_IS_ADMIN = "isAdmin";
 
     // LIST
     public static final String PATH_LIST = PATH + SLASH + ACTION_LIST;
@@ -163,7 +162,6 @@ class TeamController {
         final String self = authentication.getName();
         return Map.of(
                 MODEL_BREADCRUMBS, BREADCRUMBS_LIST,
-                MODEL_IS_ADMIN, isAdmin,
                 MODEL_MEMBERS, teamService.findAll(tenant)
                         .stream()
                         .map(m -> new MemberRow(m.email(), m.fullName(), isAdmin && !m.id().equals(self) ? deleteMemberForm(m) : null))

--- a/security-http/src/main/java/org/projectcheckins/security/http/UserViewModelProcessor.java
+++ b/security-http/src/main/java/org/projectcheckins/security/http/UserViewModelProcessor.java
@@ -1,0 +1,19 @@
+package org.projectcheckins.security.http;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.filters.SecurityFilter;
+import jakarta.inject.Singleton;
+import org.projectcheckins.security.MapViewModelProcessor;
+import java.util.Map;
+
+@Singleton
+public class UserViewModelProcessor extends MapViewModelProcessor {
+    private static final String KEY_SECURITY = "user";
+
+    @Override
+    protected void populateModel(HttpRequest<?> request, Map<String, Object> viewModel) {
+        request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class)
+                .ifPresent(authentication -> viewModel.put(KEY_SECURITY, authentication));
+    }
+}

--- a/security-http/src/main/resources/views/team/_list.html
+++ b/security-http/src/main/resources/views/team/_list.html
@@ -1,8 +1,8 @@
-<th:block th:fragment="list(breadcrumbs,isAdmin,members,invitations)" xmlns:th="http://www.thymeleaf.org">
+<th:block th:fragment="list(breadcrumbs,members,invitations)" xmlns:th="http://www.thymeleaf.org">
     <nav th:replace="~{bootstrap/_breadcrumbs :: breadcrumbs(${breadcrumbs})}"></nav>
     <article>
         <div th:replace="~{team/_members :: members(${members})}"></div>
-        <th:block th:if="${isAdmin}">
+        <th:block th:if="${user.roles.contains('ROLE_ADMIN')}">
             <div th:replace="~{team/_invitations :: invitations(${invitations})}"></div>
         </th:block>
     </article>

--- a/security-http/src/main/resources/views/team/list.html
+++ b/security-http/src/main/resources/views/team/list.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <main>
-    <nav th:replace="~{team/_list :: list(${breadcrumbs},${isAdmin},${members},${invitations})}"></nav>
+    <nav th:replace="~{team/_list :: list(${breadcrumbs},${members},${invitations})}"></nav>
 </main>
 </body>
 </html>

--- a/security-http/src/test/java/org/projectcheckins/security/http/UserViewModelProcessorTest.java
+++ b/security-http/src/test/java/org/projectcheckins/security/http/UserViewModelProcessorTest.java
@@ -1,0 +1,22 @@
+package org.projectcheckins.security.http;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest(startApplication = false)
+class UserViewModelProcessorTest {
+
+    @Inject
+    BeanContext beanContext;
+
+    @Test
+    void securityViewModelProcessorIsDisabled() {
+        assertTrue(beanContext.containsBean(UserViewModelProcessor.class));
+        assertFalse(beanContext.containsBean(io.micronaut.views.model.security.SecurityViewModelProcessor.class));
+    }
+}

--- a/security-http/src/test/resources/application-test.properties
+++ b/security-http/src/test/resources/application-test.properties
@@ -1,0 +1,1 @@
+micronaut.security.views-model-decorator.enabled=false

--- a/security/src/main/java/org/projectcheckins/security/MapViewModelProcessor.java
+++ b/security/src/main/java/org/projectcheckins/security/MapViewModelProcessor.java
@@ -1,4 +1,4 @@
-package org.projectcheckins.core.viewmodelprocessors;
+package org.projectcheckins.security;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.HttpRequest;


### PR DESCRIPTION
This PR remove the need to add a `isAdmin` to the models when we need to check roles in the view. 